### PR TITLE
支持腾讯视频以iframe形式推送至微信小程序

### DIFF
--- a/template/wxapp/app.json
+++ b/template/wxapp/app.json
@@ -20,7 +20,7 @@
         "navigationBarTitleText": "",
         "navigationBarTextStyle": "white",
         "backgroundColor": "#FFFFFF",
-        "enablePullDownRefresh":true
+        "enablePullDownRefresh": true
     },
     "tabBar": {
         "color": "#7A7E83",
@@ -53,6 +53,12 @@
         "connectSocket": 30000,
         "uploadFile": 30000,
         "downloadFile": 30000
+    },
+    "plugins": {
+      "tencentvideo": {
+        "version": "1.2.4",
+        "provider": "wxa75efa648b60994b"
+      }
     },
     "debug": true
 }

--- a/template/wxapp/pages/article/article.json
+++ b/template/wxapp/pages/article/article.json
@@ -1,5 +1,6 @@
 {
     "usingComponents": {
-        "collect-formid": "/iCMS/component/collect-formid"
+        "collect-formid": "/iCMS/component/collect-formid",
+        "txv-video": "plugin://tencentvideo/video"
     }
 }

--- a/template/wxapp/wxParse/html2json.js
+++ b/template/wxapp/wxParse/html2json.js
@@ -158,6 +158,11 @@ function html2json(html, bindName) {
                 results.imageUrls.push(imgUrl);
             }
 
+          if (node.tag === 'iframe') {
+            // safeGetValue 只是一个取值的函数，可自行编写自己的取值函数。
+            node.vid = safeGetValue([1], node.attr.src.match(/https:\/\/v\.qq\.com.*vid=(\w*)/))
+          }
+
             // 处理font标签样式属性
             if (node.tag === 'font') {
                 var fontSize = ['x-small', 'small', 'medium', 'large', 'x-large', 'xx-large', '-webkit-xxx-large'];
@@ -301,3 +306,34 @@ module.exports = {
     emojisInit:emojisInit
 };
 
+function safeGetValue() {
+  const argsLength = arguments.length
+
+  if (argsLength !== 2 && argsLength !== 3) {
+    throw '必须为两个或者三个参数'
+  }
+
+  var defaultValue
+
+  if (argsLength === 3) {
+    var [_defaultValue, keys, item] = arguments
+    defaultValue = _defaultValue
+  } else {
+    var [keys, item] = arguments
+  }
+
+
+  if (!Array.isArray(keys)) {
+    throw '参数有误，取值的keys必须为数组'
+  }
+
+  try {
+    keys.forEach(key => {
+      item = item[key]
+    })
+  } catch (e) {
+    return defaultValue
+  }
+
+  return item
+}

--- a/template/wxapp/wxParse/wxParse.wxml
+++ b/template/wxapp/wxParse/wxParse.wxml
@@ -36,6 +36,20 @@
 <template name="WxParseBr">
   <text>\n</text>
 </template>
+
+<template name="wxPraseIframe2TencentVideoPlugin">
+  <view style="margin: 20rpx 0">
+    <txv-video
+      width="100%"
+      height="600rpx"
+      playerid="txv1"
+      vid="{{item.vid}}"
+      autoplay="{{true}}">
+      <!--<cover-view class='txv-video-slot'>video slot</cover-view>-->
+    </txv-video>
+  </view>
+</template>
+
 <!--入口模版-->
 
 <template name="wxParse">
@@ -76,6 +90,11 @@
     <!--video类型-->
     <block wx:elif="{{item.tag == 'video'}}">
       <template is="wxParseVideo" data="{{item}}" />
+    </block>
+
+    <!--腾讯视频插件-->
+    <block wx:elif="{{item.tag == 'iframe'}}">
+      <template is="wxPraseIframe2TencentVideoPlugin" data="{{item}}" />
     </block>
 
     <!--img类型-->
@@ -163,6 +182,11 @@
       <template is="wxParseVideo" data="{{item}}" />
     </block>
 
+    <!--腾讯视频插件-->
+    <block wx:elif="{{item.tag == 'iframe'}}">
+      <template is="wxPraseIframe2TencentVideoPlugin" data="{{item}}" />
+    </block>
+
     <!--img类型-->
     <block wx:elif="{{item.tag == 'img'}}">
       <template is="wxParseImg" data="{{item}}" />
@@ -238,6 +262,11 @@
     <!--video类型-->
     <block wx:elif="{{item.tag == 'video'}}">
       <template is="wxParseVideo" data="{{item}}" />
+    </block>
+
+    <!--腾讯视频插件-->
+    <block wx:elif="{{item.tag == 'iframe'}}">
+      <template is="wxPraseIframe2TencentVideoPlugin" data="{{item}}" />
     </block>
 
     <!--img类型-->
@@ -316,6 +345,11 @@
       <template is="wxParseVideo" data="{{item}}" />
     </block>
 
+    <!--腾讯视频插件-->
+    <block wx:elif="{{item.tag == 'iframe'}}">
+      <template is="wxPraseIframe2TencentVideoPlugin" data="{{item}}" />
+    </block>
+
     <!--img类型-->
     <block wx:elif="{{item.tag == 'img'}}">
       <template is="wxParseImg" data="{{item}}" />
@@ -390,6 +424,11 @@
     <!--video类型-->
     <block wx:elif="{{item.tag == 'video'}}">
       <template is="wxParseVideo" data="{{item}}" />
+    </block>
+
+    <!--腾讯视频插件-->
+    <block wx:elif="{{item.tag == 'iframe'}}">
+      <template is="wxPraseIframe2TencentVideoPlugin" data="{{item}}" />
     </block>
 
     <!--img类型-->
@@ -468,6 +507,11 @@
       <template is="wxParseVideo" data="{{item}}" />
     </block>
 
+    <!--腾讯视频插件-->
+    <block wx:elif="{{item.tag == 'iframe'}}">
+      <template is="wxPraseIframe2TencentVideoPlugin" data="{{item}}" />
+    </block>
+
     <!--img类型-->
     <block wx:elif="{{item.tag == 'img'}}">
       <template is="wxParseImg" data="{{item}}" />
@@ -544,6 +588,11 @@
       <template is="wxParseVideo" data="{{item}}" />
     </block>
 
+    <!--腾讯视频插件-->
+    <block wx:elif="{{item.tag == 'iframe'}}">
+      <template is="wxPraseIframe2TencentVideoPlugin" data="{{item}}" />
+    </block>
+
     <!--img类型-->
     <block wx:elif="{{item.tag == 'img'}}">
       <template is="wxParseImg" data="{{item}}" />
@@ -617,6 +666,11 @@
     <!--video类型-->
     <block wx:elif="{{item.tag == 'video'}}">
       <template is="wxParseVideo" data="{{item}}" />
+    </block>
+
+    <!--腾讯视频插件-->
+    <block wx:elif="{{item.tag == 'iframe'}}">
+      <template is="wxPraseIframe2TencentVideoPlugin" data="{{item}}" />
     </block>
 
     <!--img类型-->
@@ -695,6 +749,11 @@
       <template is="wxParseVideo" data="{{item}}" />
     </block>
 
+    <!--腾讯视频插件-->
+    <block wx:elif="{{item.tag == 'iframe'}}">
+      <template is="wxPraseIframe2TencentVideoPlugin" data="{{item}}" />
+    </block>
+
     <!--img类型-->
     <block wx:elif="{{item.tag == 'img'}}">
       <template is="wxParseImg" data="{{item}}" />
@@ -769,6 +828,11 @@
     <!--video类型-->
     <block wx:elif="{{item.tag == 'video'}}">
       <template is="wxParseVideo" data="{{item}}" />
+    </block>
+
+    <!--腾讯视频插件-->
+    <block wx:elif="{{item.tag == 'iframe'}}">
+      <template is="wxPraseIframe2TencentVideoPlugin" data="{{item}}" />
     </block>
 
     <!--img类型-->
@@ -847,6 +911,11 @@
       <template is="wxParseVideo" data="{{item}}" />
     </block>
 
+    <!--腾讯视频插件-->
+    <block wx:elif="{{item.tag == 'iframe'}}">
+      <template is="wxPraseIframe2TencentVideoPlugin" data="{{item}}" />
+    </block>
+
     <!--img类型-->
     <block wx:elif="{{item.tag == 'img'}}">
       <template is="wxParseImg" data="{{item}}" />
@@ -921,6 +990,11 @@
     <!--video类型-->
     <block wx:elif="{{item.tag == 'video'}}">
       <template is="wxParseVideo" data="{{item}}" />
+    </block>
+
+    <!--腾讯视频插件-->
+    <block wx:elif="{{item.tag == 'iframe'}}">
+      <template is="wxPraseIframe2TencentVideoPlugin" data="{{item}}" />
     </block>
 
     <!--img类型-->


### PR DESCRIPTION
微信小程序需要申请腾讯视频插件。
在文章里用html将以下代码插入：
<iframe frameborder="0" src="https://v.qq.com/txp/iframe/player.html?vid=x0014idk286" allowFullScreen="true"></iframe>
请将x0014idk286替换为你要播放的腾讯视频的vid，小程序里就可以直接看到视频了。
源码来自于简书用户strong9527，链接：https://www.jianshu.com/p/074d6f8e6083